### PR TITLE
Implement business PDA for loyalty mint

### DIFF
--- a/srcs/backend/anchor/target/idl/loyl_token.json
+++ b/srcs/backend/anchor/target/idl/loyl_token.json
@@ -3,7 +3,7 @@
   "name": "loyl_token",
   "instructions": [
     {
-      "name": "createLoyaltyMint",
+      "name": "createLoyaltyMintWithPda",
       "accounts": [
         {
           "name": "platformConfig",
@@ -26,7 +26,12 @@
           "isSigner": false
         },
         {
-          "name": "businessAuthority",
+          "name": "businessPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
           "isMut": true,
           "isSigner": true
         },
@@ -98,12 +103,21 @@
       ],
       "args": [
         {
-          "name": "rateLoyl",
-          "type": "u64"
+          "name": "businessId",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
         },
         {
           "name": "decimals",
           "type": "u8"
+        },
+        {
+          "name": "rateLoyl",
+          "type": "u64"
         },
         {
           "name": "initialSupply",


### PR DESCRIPTION
## Summary
- add `Business` PDA and use it for loyalty minting
- update `createLoyaltyMint` flow to `createLoyaltyMintWithPda`
- adjust IDL with new instruction and account names

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f0c8a6e40832ea9539e65dead6d40